### PR TITLE
Add the Csound sound compiler

### DIFF
--- a/boxes.yml
+++ b/boxes.yml
@@ -717,6 +717,9 @@ ubuntu-base:
   apache2-rewrite:
     _name: Apache mod_rewrite
     _link: https://httpd.apache.org/docs/2.4/rewrite/
+  csound:
+    _name: Csound
+    _link: https://csound.com/
 brainfuck-bfi:
   _name: Brainfuck (BFI)
   _link: http://esoteric.sange.fi/brainfuck/impl/interp/BFI.c

--- a/boxes/csound/Dockerfile
+++ b/boxes/csound/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
+    mv /bin/csound /bin/csound-original && \
     ln -s /bin/script /bin/csound
 
 COPY script /root/script
-
-RUN chmod +x /root/script

--- a/boxes/csound/Dockerfile
+++ b/boxes/csound/Dockerfile
@@ -6,7 +6,7 @@ COPY rmsil.c /tmp/rmsil.c
 
 RUN apt-get update && \
     apt-get install -y build-essential csound && \
-    gcc -o ~/rmsil /tmp/rmsil.c
+    gcc -o ~/rmsil /tmp/rmsil.c && \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \

--- a/boxes/csound/Dockerfile
+++ b/boxes/csound/Dockerfile
@@ -1,0 +1,17 @@
+FROM esolang/ubuntu-base
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY rmsil.c /tmp/rmsil.c
+
+RUN apt-get update && \
+    apt-get install -y build-essential csound && \
+    gcc -o ~/rmsil /tmp/rmsil.c
+    apt-get autoremove -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* && \
+    ln -s /bin/script /bin/csound
+
+COPY script /root/script
+
+RUN chmod +x /root/script

--- a/boxes/csound/rmsil.c
+++ b/boxes/csound/rmsil.c
@@ -1,3 +1,24 @@
+/**
+ * rmsil.c
+ *
+ * Copyright 2021 ikubaku <hide4d51 at gmail.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+ * and associated documentation files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom
+ * the Software is furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+ * BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 #include <stdio.h>
 
 #define B_SIL 0x80

--- a/boxes/csound/rmsil.c
+++ b/boxes/csound/rmsil.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+
+#define B_SIL 0x80
+
+int main(void) {
+  size_t i;
+  int in_c;
+  size_t sil_runlength = 0;
+
+  while((in_c = getchar()) != EOF) {
+    if(in_c == B_SIL) {
+      sil_runlength++;
+    } else {
+      for(i=0; i<sil_runlength; i++) {
+        putchar(B_SIL);
+      }
+      sil_runlength = 0;
+      putchar(in_c);
+    }
+  }
+}

--- a/boxes/csound/script
+++ b/boxes/csound/script
@@ -9,7 +9,7 @@ cat - > input.in
 insize=$(wc -c < input.in)
 sed -i "s/<CsScore>/<CsScore>\n#define SIZE #$insize#/" code.csd
 
-csound -i input.in -o output.out --format=raw:uchar -b 1 code.csd
+csound-original -i input.in -o output.out --format=raw:uchar -b 1 code.csd
 
 # Remove trailing silence samples
 ~/rmsil < output.out

--- a/boxes/csound/script
+++ b/boxes/csound/script
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+infile=$(realpath "$1")
+ln -sf "$infile" /tmp/code.csd
+cd /tmp
+
+# Add the score macro to obtain the input length
+cat - > input.in
+insize=$(wc -c < input.in)
+sed -i "s/<CsScore>/<CsScore>\n#define SIZE #$insize#/" code.csd
+
+csound -i input.in -o output.out --format=raw:uchar -b 1 code.csd
+
+# Remove trailing silence samples
+~/rmsil < output.out
+
+rm /tmp/{code.csd,input.in,output.out}

--- a/dobi.yaml
+++ b/dobi.yaml
@@ -236,6 +236,7 @@ alias=all:
   - egison
   - sqlite3
   - imagemagick
+  - csound
   - brainfuck-bfi
 image=base:
   image: esolang/base
@@ -2118,6 +2119,14 @@ image=sqlite3:
 image=imagemagick:
   image: esolang/imagemagick
   context: boxes/imagemagick
+  tags:
+  - latest
+  - 2.3.0
+  depends:
+  - ubuntu-base
+image=csound
+  image: esolang/csound
+  context: boxes/csound
   tags:
   - latest
   - 2.3.0

--- a/spec/assets/README.md
+++ b/spec/assets/README.md
@@ -238,7 +238,7 @@ Contents under this directory retains their original licenses.
 * `hello.cpp`: Original
 * `hello.cr`: [crystal-lang.org](https://crystal-lang.org/docs/overview/hello_world.html)
 * `hello.cs`: Original
-& `hello.csd`: Original
+* `hello.csd`: Original
 * `hello.cubically`: [DennisMitchell](https://github.com/TryItOnline/tryitonline/commit/dbf1833d97cbee95d8b2f1163d39272ca6dcc3ac#diff-7aebd80e086be04d6b5c4c9af3361764R2496)
 * `hello.cubix`: [ETHproductions](https://github.com/ETHproductions/cubix#hello-world)
 * `hello.cy`: [cyoce](https://github.com/cyoce/Cy#hello-world-program)

--- a/spec/assets/README.md
+++ b/spec/assets/README.md
@@ -43,6 +43,7 @@ Contents under this directory retains their original licenses.
 * `cat.coq.v`: [coq.io](http://coq.io/getting_started.html)
 * `cat.cr`: Original
 * `cat.cs`: Original
+* `cat.csd`: Original
 * `cat.cubically`: [aaronryank](https://github.com/aaronryank/Cubically/blob/master/examples/cat.cb)
 * `cat.cubix`: [ETHproductions](https://github.com/ETHproductions/cubix#cat)
 * `cat.cy`: Original
@@ -237,6 +238,7 @@ Contents under this directory retains their original licenses.
 * `hello.cpp`: Original
 * `hello.cr`: [crystal-lang.org](https://crystal-lang.org/docs/overview/hello_world.html)
 * `hello.cs`: Original
+& `hello.csd`: Original
 * `hello.cubically`: [DennisMitchell](https://github.com/TryItOnline/tryitonline/commit/dbf1833d97cbee95d8b2f1163d39272ca6dcc3ac#diff-7aebd80e086be04d6b5c4c9af3361764R2496)
 * `hello.cubix`: [ETHproductions](https://github.com/ETHproductions/cubix#hello-world)
 * `hello.cy`: [cyoce](https://github.com/cyoce/Cy#hello-world-program)

--- a/spec/assets/cat.csd
+++ b/spec/assets/cat.csd
@@ -1,0 +1,17 @@
+<CsoundSynthesizer>
+<CsInstruments>
+sr = 1
+kr = 1
+ksmps = 1
+
+instr 1
+aIn inch 1
+out aIn
+endin
+
+</CsInstruments>
+
+<CsScore>
+i 1 0 $SIZE
+</CsScore>
+</CsoundSynthesizer>

--- a/spec/assets/hello.csd
+++ b/spec/assets/hello.csd
@@ -1,0 +1,31 @@
+<CsoundSynthesizer>
+<CsInstruments>
+sr = 1
+kr = 1
+ksmps = 1
+
+instr 1
+icH = -14336
+ice = -6912
+icl = -5120
+ico = -4352
+iComma = -21504
+iSpace = -24576
+icW = -10496
+icr = -3584
+icd = -7168
+iExcl = -24320
+iNewline = -30208
+iRestbl ftgen 2, 0, 32, -7, icH, 1, icH, 0, ice, 1, ice, 0, icl, 1, icl, 0, icl, 1, icl, 0, ico, 1, ico, 0, iComma, 1, iComma, 0, iSpace, 1, iSpace, 0, icW, 1, icW, 0, ico, 1, ico, 0, icr, 1, icr, 0, icl, 1, icl, 0, icd, 1, icd, 0, iExcl, 1, iExcl, 0, iNewline, 1, iNewline, 0
+
+aRes osciln 1, 1, iRestbl, 15
+out aRes
+endin
+
+</CsInstruments>
+
+<CsScore>
+i 1 0 16
+e
+</CsScore>
+</CsoundSynthesizer>

--- a/spec/boxes_spec.rb
+++ b/spec/boxes_spec.rb
@@ -1181,7 +1181,7 @@ describe 'esolang-box', v2: true do
   end
 
   describe 'csound' do
-    it { expect(result_of(subject, 'hello.csd')).to eql("Hello, world!\n") }
+    it { expect(result_of(subject, 'hello.csd')).to eql("Hello, World!\n") }
     it { expect(result_of(subject, 'cat.csd', "meow")).to eql("meow") }
   end
 end

--- a/spec/boxes_spec.rb
+++ b/spec/boxes_spec.rb
@@ -1179,4 +1179,9 @@ describe 'esolang-box', v2: true do
     it { expect(result_of(subject, 'hello.apache2-rewrite.conf')).to eql("Hello, world!") }
     it { expect(result_of(subject, 'cat.apache2-rewrite.conf', "meow")).to eql("meow") }
   end
+
+  describe 'csound' do
+    it { expect(result_of(subject, 'hello.csd')).to eql("Hello, world!\n") }
+    it { expect(result_of(subject, 'cat.csd', "meow")).to eql("meow") }
+  end
 end


### PR DESCRIPTION
言語の制約上このboxには以下の特別ルールがあります:
- 入力は次の2つの形式で与えられます
  - Csoundの入力音声データ（opcode `inch 1` で取得可能な符号なし8bit生PCM音声データとして）
  - cwdのデータファイル(./input.in)
- 入力データのサイズが答案ソースコードの一部を置換することによってスコアのマクロとして与えられます（スコア中の `$SIZE` が入力のバイト数に置き換えられます）
- 出力データ末尾の0x80（無音サンプル）はジャッジ前にすべて除去されます