### PR TITLE
add nim-lang

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ sys     0m 13.73s
     * [`esolang/sqlite3`](https://hub.docker.com/r/esolang/sqlite3/): [SQLite3](https://sqlite.org/)
     * [`esolang/imagemagick`](https://hub.docker.com/r/esolang/imagemagick/): [ImageMagick](https://imagemagick.org/)
     * [`esolang/apache2-rewrite`](https://hub.docker.com/r/esolang/apache2-rewrite/): [Apache mod_rewrite](https://httpd.apache.org/docs/2.4/rewrite/)
+    * [`esolang/nim-lang`](https://hub.docker.com/r/esolang/nim/): [Nim](https://nim-lang.org/)
 * [`esolang/brainfuck-bfi`](https://hub.docker.com/r/esolang/brainfuck-bfi/): [Brainfuck (BFI)](http://esoteric.sange.fi/brainfuck/impl/interp/BFI.c)
 
 ## Notes about some languages

--- a/boxes.yml
+++ b/boxes.yml
@@ -717,6 +717,9 @@ ubuntu-base:
   apache2-rewrite:
     _name: Apache mod_rewrite
     _link: https://httpd.apache.org/docs/2.4/rewrite/
+  nim-lang:
+    _name: Nim
+    _link: https://nim-lang.org/
   csound:
     _name: Csound
     _link: https://csound.com/

--- a/boxes/nim-lang/Dockerfile
+++ b/boxes/nim-lang/Dockerfile
@@ -1,5 +1,4 @@
 FROM esolang/ubuntu-base
-RUN apt-get update && apt-get install -y nim
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh && \
     sed -i -e 's/need_tty=yes/need_tty=no/' init.sh && \
     sh init.sh

--- a/boxes/nim-lang/Dockerfile
+++ b/boxes/nim-lang/Dockerfile
@@ -1,0 +1,7 @@
+FROM esolang/ubuntu-base
+RUN apt-get update && apt-get install -y nim
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh && \
+    sed -i -e 's/need_tty=yes/need_tty=no/' init.sh && \
+    sh init.sh
+RUN ln -s /bin/script /bin/nim-lang
+COPY script /root/script

--- a/boxes/nim-lang/script
+++ b/boxes/nim-lang/script
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd /root
+cp $(realpath "$1") /root/code.nim
+cat - | /root/.nimble/bin/nim cpp --hints:off --verbosity:0 -d:release -r /root/code.nim
+rm /root/code.nim /root/code

--- a/spec/assets/README.md
+++ b/spec/assets/README.md
@@ -319,7 +319,7 @@ Contents under this directory retains their original licenses.
 * `hello.modan`: [yhara](https://github.com/yhara/ShogiModan/blob/master/README.mkd)
 * `hello.moo`: [moratorium08](https://github.com/moratorium08/moo/blob/master/example/helloworld.moo)
 * `hello.nako3`: Original
-* `hello.nim` : [im-by-example.github.io](https://nim-by-example.github.io/hello_world/)
+* `hello.nim` : [nim-by-example.github.io](https://nim-by-example.github.io/hello_world/)
 * `hello.notenglish`: [esolangs.org](https://esolangs.org/wiki/~English#Examples)
 * `hello.nuts`: [hoge-fuga-0000](https://github.com/hoge-fuga-0000/Nuts/blob/gh-pages/nuts-samples.js#L4)
 * `hello.ogc`: [phase](https://github.com/phase/o/blob/master/examples/helloWorld.ogc)

--- a/spec/assets/README.md
+++ b/spec/assets/README.md
@@ -114,6 +114,7 @@ Contents under this directory retains their original licenses.
 * `cat.ml`: Original
 * `cat.moo`: [moratorium08](https://github.com/moratorium08/moo/blob/master/example/cat.moo)
 * `cat.nako3`: Original
+* `cat.nim`: Original
 * `cat.notenglish`: Original
 * `cat.nuts`: [hoge-fuga-0000](https://github.com/hoge-fuga-0000/Nuts/blob/gh-pages/nuts-samples.js#L3)
 * `cat.ogc`: [phase](https://github.com/phase/o/blob/master/examples/cat.ogc)
@@ -318,6 +319,7 @@ Contents under this directory retains their original licenses.
 * `hello.modan`: [yhara](https://github.com/yhara/ShogiModan/blob/master/README.mkd)
 * `hello.moo`: [moratorium08](https://github.com/moratorium08/moo/blob/master/example/helloworld.moo)
 * `hello.nako3`: Original
+* `hello.nim` : [im-by-example.github.io](https://nim-by-example.github.io/hello_world/)
 * `hello.notenglish`: [esolangs.org](https://esolangs.org/wiki/~English#Examples)
 * `hello.nuts`: [hoge-fuga-0000](https://github.com/hoge-fuga-0000/Nuts/blob/gh-pages/nuts-samples.js#L4)
 * `hello.ogc`: [phase](https://github.com/phase/o/blob/master/examples/helloWorld.ogc)

--- a/spec/assets/cat.nim
+++ b/spec/assets/cat.nim
@@ -1,0 +1,1 @@
+stdout.write stdin.readAll

--- a/spec/assets/hello.nim
+++ b/spec/assets/hello.nim
@@ -1,0 +1,1 @@
+echo "Hello, World!"

--- a/spec/boxes_spec.rb
+++ b/spec/boxes_spec.rb
@@ -1184,4 +1184,9 @@ describe 'esolang-box', v2: true do
     it { expect(result_of(subject, 'hello.csd')).to eql("Hello, World!\n") }
     it { expect(result_of(subject, 'cat.csd', "meow")).to eql("meow") }
   end
+
+  describe 'nim-lang' do
+    it { expect(result_of(subject, 'hello.nim')).to eql("Hello, World!\n") }
+    it { expect(result_of(subject, 'cat.nim', "meow! meW12")).to eql("meow! meW12") }
+  end
 end


### PR DESCRIPTION
Nim(最新1.4.4) です。
`nim` という名前で登録すると `minimal2d` の部分文字列になり、rspecに対応が必要なので、 `nim-lang` としています。